### PR TITLE
unnanounce strawman, closes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Options include:
 When the topic is destroyed the port will be explicitly unannounced
 from the network as well
 
+#### `d.unnanounce(topic, cb)`
+
+The topic returned from `d.announce` can be passed in to `d.unnanounce` 
+to stop announcing the topic. 
+
+#### `topic.unnanounce(cb)`
+
+Unnanounce a topic, this is the same as passing a `topic` into `d.unnanounce`.
+
 #### `d.lookupOne(key, cb)`
 
 Find a single peer and returns that to the callback.

--- a/example.js
+++ b/example.js
@@ -3,13 +3,13 @@ const discovery = require('./')
 const d = discovery()
 const k = Buffer.alloc(32)
 
-// const topic = d.lookup(k)
-// topic.on('peer', peer => console.log('peer:', peer))
+const topic = d.lookup(k)
+topic.on('peer', peer => console.log('peer:', peer))
 
 d.announce(k, {
   port: 10000,
   lookup: true
-}).on('peer', console.log)
+}).on('peer', peer => console.log('peer:', peer))
 
 const ann = d.announce(k, {
   port: 10101
@@ -17,12 +17,14 @@ const ann = d.announce(k, {
 
 ann.once('update', function () {
   console.log('onupdate')
-  ann.destroy()
-  ann.once('close', function () {
-    console.log('onclose')
+  d.unannounce(ann, () => {
     const d2 = discovery()
-
     d2.lookup(k)
-      .on('peer', console.log)
+      .on('peer', peer => console.log('more peers:', peer)) 
+    setTimeout(() => {
+      ann.destroy()
+    }, 1000);
   })
 })
+
+setTimeout


### PR DESCRIPTION
if we accept `topic` instead of `key` into `unnanounce` we don't have to keep a map of keys to announced topics (the keys would also have to be converted to hex etc). 

so here's a strawman with request for comment